### PR TITLE
Actual and expected transcriptions are cleaned to produce similar output.

### DIFF
--- a/src/ResponseAnalyzer.ts
+++ b/src/ResponseAnalyzer.ts
@@ -24,10 +24,10 @@ export class ResponseAnalyzer {
         response: DetailedSpeechPhrase
     ): TestResult => {
         try {
-            const actualTranscription = response.NBest[0].Lexical.toLowerCase();
+            const actualTranscription = response.NBest[0].Lexical;
 
-            // Check if the transcription contains special characters that the
-            // system does not currently account for.
+            // Clean the transcription, then check if it contains special
+            // characters that the system does not currently account for.
             this.transcriptAnalyzer.analyzeActualTranscription(actualTranscription);
 
             const wordErrorRate = calculateWER(actualTranscription, expectedTranscription);

--- a/src/ResponseAnalyzer.ts
+++ b/src/ResponseAnalyzer.ts
@@ -24,13 +24,20 @@ export class ResponseAnalyzer {
         response: DetailedSpeechPhrase
     ): TestResult => {
         try {
-            const actualTranscription = response.NBest[0].Lexical;
+            let actualTranscription = response.NBest[0].Lexical;
 
-            // Clean the transcription, then check if it contains special
-            // characters that the system does not currently account for.
-            this.transcriptAnalyzer.analyzeActualTranscription(actualTranscription);
+            // Clean the transcription of specific patterns that are sometimes
+            // returned from the STT service.
+            actualTranscription = this.transcriptAnalyzer.
+                cleanActualTranscription(actualTranscription);
 
-            const wordErrorRate = calculateWER(actualTranscription, expectedTranscription);
+            // Check if the transcription contains special characters that the
+            // system does not currently account for.
+            this.transcriptAnalyzer.
+                analyzeActualTranscription(actualTranscription);
+
+            const wordErrorRate = calculateWER(
+                actualTranscription, expectedTranscription);
 
             console.log(`Actual Response: "${actualTranscription}"`);
             console.log(`Expected Response: "${expectedTranscription}"`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,8 +49,8 @@ export const start = async () => {
         const parsedData: TestData = tfs.createTestData(transcriptionFile, audioDirectory);
 
         for (const testDatum of parsedData) {
+            testDatum.transcription = transcriptAnalyzer.cleanTranscription(testDatum.transcription);
             transcriptAnalyzer.validateExpectedTranscription(testDatum.transcription);
-            testDatum.transcription = transcriptAnalyzer.cleanExpectedTranscription(testDatum.transcription);
         }
 
         await service.batchTranscribe(parsedData, Number.parseInt(concurrency))


### PR DESCRIPTION
Both the expected and actual transcriptions are cleaned in the following way in `cleanTranscription()`:
* Lowercase
* `okay` is replaced with `ok`

*Only the expected transcription* will throw an error in `validateExpectedTranscription` if it contains anything other than:
* Lowercase letters
   * Everything is cast to lowercase anyway, so humans working on transcription files don't need to worry about this.
* Apostrophes
* Spaces

*Only the actual transcription* is cleaned in the following way in `cleanActualTranscription`:
* Commas, periods, and question marks are replaced with an empty string. **(NEW)**
* " 's" is replaced with "s" **(NEW)**