### PR TITLE
only use false negatives when it exists in expectedUtterance

### DIFF
--- a/packages/d-ser-t-service/src/ResponseAnalyzer.ts
+++ b/packages/d-ser-t-service/src/ResponseAnalyzer.ts
@@ -29,7 +29,7 @@ export class ResponseAnalyzer {
             // Clean the transcription of specific patterns that are sometimes
             // returned from the STT service.
             actualTranscription = this.transcriptAnalyzer.
-                cleanActualTranscription(actualTranscription);
+                cleanActualTranscription(actualTranscription, expectedTranscription);
 
             // Check if the transcription contains special characters that the
             // system does not currently account for.

--- a/packages/d-ser-t-service/src/TranscriptionAnalyzer.ts
+++ b/packages/d-ser-t-service/src/TranscriptionAnalyzer.ts
@@ -18,7 +18,7 @@ export class TranscriptionAnalyzer extends TranscriptionAnalyzerBase {
      * would have to assume no typos were made. Instead, we expect the human
      * completing the transcription file to do so correctly.
      */
-    public cleanActualTranscription = (actualTranscription: string): string => {
+    public cleanActualTranscription = (actualTranscription: string, expectedTranscription: string): string => {
         return this.cleanTranscription(actualTranscription)
             // Replace commas, periods, and question marks with an empty string.
             .replace(/,|\.|\?/g, ``)

--- a/packages/d-ser-t-service/src/TranscriptionAnalyzerBase.ts
+++ b/packages/d-ser-t-service/src/TranscriptionAnalyzerBase.ts
@@ -53,7 +53,7 @@ export class TranscriptionAnalyzerBase implements ITranscriptionAnalyzer {
      * The STT service will **sometimes** return commas, periods, question
      * marks, and more. This method is meant to further process the input
      */
-    public cleanActualTranscription = (actualTranscription: string): string => {
+    public cleanActualTranscription = (actualTranscription: string, expectedTranscription: string): string => {
         return this.cleanTranscription(actualTranscription);
     };
 

--- a/packages/d-ser-t-service/src/TranscriptionAnalyzerCI.ts
+++ b/packages/d-ser-t-service/src/TranscriptionAnalyzerCI.ts
@@ -10,7 +10,7 @@ export class TranscriptionAnalyzerCI extends TranscriptionAnalyzerBase {
         this.configFile = exceptions;
     }
 
-    public cleanActualTranscription = (actualTranscription: string): string => {
+    public cleanActualTranscription = (actualTranscription: string, expectedTranscription: string): string => {
         let result: string = this.cleanTranscription(actualTranscription)
         let config: CleanUpConfig = <CleanUpConfig>Utils.readJSONFileSync(this.configFile);
 
@@ -25,7 +25,7 @@ export class TranscriptionAnalyzerCI extends TranscriptionAnalyzerBase {
                 continue;
             }
 
-            if (result.includes(key)) {
+            if (expectedTranscription.includes(value) && result.includes(key)) {
                 result = result.replace(key, value);
             }
         }

--- a/packages/d-ser-t-service/src/interfaces/ITranscriptionAnalyzer.ts
+++ b/packages/d-ser-t-service/src/interfaces/ITranscriptionAnalyzer.ts
@@ -1,7 +1,7 @@
 export interface ITranscriptionAnalyzer {
     validateExpectedTranscription(expectedTranscription: string): void;
     cleanTranscription(expectedTranscription: string): string;
-    cleanActualTranscription(actualTranscription: string): string;
+    cleanActualTranscription(actualTranscription: string, expectedTranscription: string): string;
     analyzeActualTranscription(actual: string): void;
     pushUnhandledOutput(char: string, word: string, actual: string): void;
 }

--- a/packages/d-ser-t-service/tests/TranscriptionAnalyzer.test.ts
+++ b/packages/d-ser-t-service/tests/TranscriptionAnalyzer.test.ts
@@ -7,15 +7,15 @@ const transcriptAnalyzer = new TranscriptionAnalyzerCI(configFile);
 
 describe("Can TranscriptionAnalyzerCI transcribe", () => {
     it("should handle punctuations", () => {
-        expect(transcriptAnalyzer.cleanActualTranscription("hello, this. is a Test?"))
+        expect(transcriptAnalyzer.cleanActualTranscription("hello, this. is a Test?", "hello this is a test"))
             .toEqual("hello this is a test");
     });
     it("should handle words in exception list", () => {
-        expect(transcriptAnalyzer.cleanActualTranscription("all right, this is a test?"))
+        expect(transcriptAnalyzer.cleanActualTranscription("all right, this is a test?", "alright this is a test"))
             .toEqual("alright this is a test");
     });
     it("should handle 's", () => {
-        expect(transcriptAnalyzer.cleanActualTranscription("all right, it 's a test?"))
+        expect(transcriptAnalyzer.cleanActualTranscription("all right, it 's a test?", "alright its a test"))
             .toEqual("alright its a test");
     });
 });

--- a/packages/d-ser-t-service/tests/helpers.test.ts
+++ b/packages/d-ser-t-service/tests/helpers.test.ts
@@ -49,11 +49,11 @@ describe('validateExpectedTranscription', () => {
 
 describe('cleanExpectedTranscription', () => {
     it('Does NOT replace hyphens with space', () => {
-        expect(transcriptAnalyzer.cleanActualTranscription('test-harness')).not.toEqual('test harness');
+        expect(transcriptAnalyzer.cleanActualTranscription('test-harness', 'test harness')).not.toEqual('test harness');
     });
 
     it('Lowercases strings', () => {
-        expect(transcriptAnalyzer.cleanActualTranscription("THIS IS SPARTA"))
+        expect(transcriptAnalyzer.cleanActualTranscription("THIS IS SPARTA", "this is sparta"))
             .toStrictEqual('this is sparta');
     });
 })


### PR DESCRIPTION
Right now the logic checks for "keys" in each actualTranscription, as opposed to checking for the "value" in each expected, or at least both. I strongly feel that we should only be doing a replace if the expectedTranscription has that value in it.