### PR TITLE
Changes to XML file output and refactoring of main.ts constructor

### DIFF
--- a/packages/d-ser-t-service/src/XmlWriterService.ts
+++ b/packages/d-ser-t-service/src/XmlWriterService.ts
@@ -67,10 +67,11 @@ export class XmlWriterService {
             .att('avg_WER', metadata.averageWordErrorRate);
 
         results.forEach((tc, index) => {
+            const filename = path.parse(metadata.transcriptionFile).base;
             const testcase = testsuite
                 .ele('testcase')
                 .att('classname', `test-${index + 1}`)
-                .att('name', `test-${index + 1}`)
+                .att('name', filename)
                 .att('time', 'n/a')
                 .att('expected', tc.expectedTranscription);
 

--- a/packages/d-ser-t-service/src/XmlWriterService.ts
+++ b/packages/d-ser-t-service/src/XmlWriterService.ts
@@ -44,6 +44,7 @@ export class XmlWriterService {
         const numTests = results.length;
         const numFailures = this.countNumFailures(results);
         const testingTime = this.getNumericalTime(metadata);
+        let sumWER = 0;
 
         const testsuites = builder
             .create('testsuites', { encoding: 'utf-8' })
@@ -51,7 +52,8 @@ export class XmlWriterService {
             .att('tests', numTests)
             .att('failures', numFailures)
             .att('time', testingTime)
-            .att('avg_SER', metadata.sentenceErrorRate);
+            .att('avg_SER', metadata.sentenceErrorRate)
+            .att('avg_WER');
 
         const testsuite = testsuites
             .ele('testsuite')
@@ -72,6 +74,8 @@ export class XmlWriterService {
                 .att('time', 'n/a')
                 .att('expected', tc.expectedTranscription);
 
+            sumWER += tc.wordErrorRate;
+
             if (tc.wordErrorRate > 0) {
                 testcase
                     .ele('failure')
@@ -81,7 +85,12 @@ export class XmlWriterService {
             }
             testcase.end({ pretty: true });
         });
+        const avgWER = sumWER / numTests;
+
+        testsuite.att('avg_WER', avgWER);
         testsuite.end({ pretty: true });
+
+        testsuites.att('avg_WER', avgWER);
         const finalXml = testsuites.end({ pretty: true });
 
         return finalXml.toString();

--- a/packages/d-ser-t-service/src/XmlWriterService.ts
+++ b/packages/d-ser-t-service/src/XmlWriterService.ts
@@ -44,7 +44,6 @@ export class XmlWriterService {
         const numTests = results.length;
         const numFailures = this.countNumFailures(results);
         const testingTime = this.getNumericalTime(metadata);
-        let sumWER = 0;
 
         const testsuites = builder
             .create('testsuites', { encoding: 'utf-8' })
@@ -53,7 +52,7 @@ export class XmlWriterService {
             .att('failures', numFailures)
             .att('time', testingTime)
             .att('avg_SER', metadata.sentenceErrorRate)
-            .att('avg_WER');
+            .att('avg_WER', metadata.averageWordErrorRate);
 
         const testsuite = testsuites
             .ele('testsuite')
@@ -64,7 +63,8 @@ export class XmlWriterService {
             .att('timestamp', timestamp)
             .att('time', testingTime)
             .att('tests', numTests)
-            .att('SER', metadata.sentenceErrorRate);
+            .att('SER', metadata.sentenceErrorRate)
+            .att('avg_WER', metadata.averageWordErrorRate);
 
         results.forEach((tc, index) => {
             const testcase = testsuite
@@ -73,8 +73,6 @@ export class XmlWriterService {
                 .att('name', `test-${index + 1}`)
                 .att('time', 'n/a')
                 .att('expected', tc.expectedTranscription);
-
-            sumWER += tc.wordErrorRate;
 
             if (tc.wordErrorRate > 0) {
                 testcase
@@ -85,12 +83,7 @@ export class XmlWriterService {
             }
             testcase.end({ pretty: true });
         });
-        const avgWER = sumWER / numTests;
-
-        testsuite.att('avg_WER', avgWER);
         testsuite.end({ pretty: true });
-
-        testsuites.att('avg_WER', avgWER);
         const finalXml = testsuites.end({ pretty: true });
 
         return finalXml.toString();

--- a/packages/d-ser-t-service/src/main.ts
+++ b/packages/d-ser-t-service/src/main.ts
@@ -78,7 +78,7 @@ export class CustomSpeechTestHarness {
         );
         this.responseAnalyzer = new ResponseAnalyzer(this.transcriptAnalyzer);
         this.xmlWriterService = new XmlWriterService();
-        this.defineOutFile(String(this.outFile));
+        this.outFile = this.defineOutFile(String(this.outFile));
     }
 
     public async singleFileTranscription() {

--- a/packages/d-ser-t-service/src/main.ts
+++ b/packages/d-ser-t-service/src/main.ts
@@ -37,17 +37,16 @@ export class CustomSpeechTestHarness {
         this.concurrency = harnessConfig.concurrentCalls;
         this.crisEndpointId = harnessConfig.endpointId;
         this.exceptions = harnessConfig.exceptions;
+        this.outFile = this.defineOutFile(String(harnessConfig.outFile));
         this.serviceRegion = harnessConfig.region;
         this.singleFile = harnessConfig.audioFile;
         this.subscriptionKey = harnessConfig.subscriptionKey;
         this.transcriptionFile = harnessConfig.transcriptionFile;
+    }
 
-        if (
-            ['json', 'xml'].includes(
-                path.extname(String(harnessConfig.outFile)).substr(1)
-            )
-        ) {
-            this.outFile = String(harnessConfig.outFile);
+    public defineOutFile(filename: string): string {
+        if (['json', 'xml'].includes(path.extname(filename).substr(1))) {
+            return filename;
         } else {
             const warnMsg = `\nOutput file types other than .json or .xml are unsupported - using .json by default.\n`;
             console.warn(warnMsg);
@@ -58,7 +57,7 @@ export class CustomSpeechTestHarness {
                     'Creating default directory test_results for test output.\n'
                 );
             }
-            this.outFile = defaultDir + '/test_results.json';
+            return defaultDir + '/test_results.json';
         }
     }
 

--- a/packages/d-ser-t-service/src/main.ts
+++ b/packages/d-ser-t-service/src/main.ts
@@ -37,7 +37,7 @@ export class CustomSpeechTestHarness {
         this.concurrency = harnessConfig.concurrentCalls;
         this.crisEndpointId = harnessConfig.endpointId;
         this.exceptions = harnessConfig.exceptions;
-        this.outFile = this.defineOutFile(String(harnessConfig.outFile));
+        this.outFile = harnessConfig.outFile as string;
         this.serviceRegion = harnessConfig.region;
         this.singleFile = harnessConfig.audioFile;
         this.subscriptionKey = harnessConfig.subscriptionKey;
@@ -78,6 +78,7 @@ export class CustomSpeechTestHarness {
         );
         this.responseAnalyzer = new ResponseAnalyzer(this.transcriptAnalyzer);
         this.xmlWriterService = new XmlWriterService();
+        this.defineOutFile(String(this.outFile));
     }
 
     public async singleFileTranscription() {

--- a/packages/d-ser-t-service/tests/XmlWriterService.test.ts
+++ b/packages/d-ser-t-service/tests/XmlWriterService.test.ts
@@ -60,10 +60,10 @@ describe('XMLWriterService', () => {
             `<?xml version="1.0" encoding="utf-8"?>\n` +
             `<testsuites name="CRIS STT tests" tests="2" failures="1" time="10" avg_SER="0.5" avg_WER="0.5">\n` +
             `  <testsuite name="test_transcription_file.txt" errors="0" failures="1" skipped="0" timestamp="2019-01-01 00:00:00" time="10" tests="2" SER="0.5" avg_WER="0.5">\n` +
-            `    <testcase classname="test-1" name="test-1" time="n/a" expected="alright">\n` +
+            `    <testcase classname="test-1" name="test_transcription_file.txt" time="n/a" expected="alright">\n` +
             `      <failure actual="all right" WER="1"/>\n` +
             `    </testcase>\n` +
-            `    <testcase classname="test-2" name="test-2" time="n/a" expected="hi"/>\n` +
+            `    <testcase classname="test-2" name="test_transcription_file.txt" time="n/a" expected="hi"/>\n` +
             `  </testsuite>\n` +
             `</testsuites>`;
 

--- a/packages/d-ser-t-service/tests/XmlWriterService.test.ts
+++ b/packages/d-ser-t-service/tests/XmlWriterService.test.ts
@@ -58,8 +58,8 @@ describe('XMLWriterService', () => {
     describe('toJUnitXml', () => {
         const expected =
             `<?xml version="1.0" encoding="utf-8"?>\n` +
-            `<testsuites name="CRIS STT tests" tests="2" failures="1" time="10" avg_SER="0.5">\n` +
-            `  <testsuite name="test_transcription_file.txt" errors="0" failures="1" skipped="0" timestamp="2019-01-01 00:00:00" time="10" tests="2" SER="0.5">\n` +
+            `<testsuites name="CRIS STT tests" tests="2" failures="1" time="10" avg_SER="0.5" avg_WER="0.5">\n` +
+            `  <testsuite name="test_transcription_file.txt" errors="0" failures="1" skipped="0" timestamp="2019-01-01 00:00:00" time="10" tests="2" SER="0.5" avg_WER="0.5">\n` +
             `    <testcase classname="test-1" name="test-1" time="n/a" expected="alright">\n` +
             `      <failure actual="all right" WER="1"/>\n` +
             `    </testcase>\n` +


### PR DESCRIPTION
* Adds average word error rate as an attribute at <testsuites> and <testsuite> level of XML
* Makes the 'name' attribute of each <testcase> the transcription text filename
* Refactors out the logic re: naming of the outfile in the constructor of main.ts