### PR TITLE
Bug fixes with batch recognition

### DIFF
--- a/packages/d-ser-t-service/src/MultiFilePullStream.ts
+++ b/packages/d-ser-t-service/src/MultiFilePullStream.ts
@@ -12,8 +12,12 @@ export class MultiFilePullStream extends PullAudioInputStreamCallback {
             return 0;
         }
 
+        const copyArray = new Uint8Array(dataBuffer);
+
         if (this.currentOffset >= this.currentFile.byteLength) {
+
             // The file has been fully read. Send silence back.
+            copyArray.fill(0);
             return dataBuffer.byteLength;
         }
 
@@ -25,7 +29,6 @@ export class MultiFilePullStream extends PullAudioInputStreamCallback {
             dataBuffer.byteLength
         );
 
-        const copyArray = new Uint8Array(dataBuffer);
         copyArray.set(
             new Uint8Array(
                 this.currentFile.slice(

--- a/packages/d-ser-t-service/src/TranscriptionService.ts
+++ b/packages/d-ser-t-service/src/TranscriptionService.ts
@@ -251,10 +251,11 @@ export class TranscriptionService {
                             `New file into stream, ${currentFileIndex}/${dataArray.length}, recognizer: ${recognizerID}`
                         );
                         stream.setFile(
-                            (dataArray[currentFileIndex++] as TestDatum)
+                            (dataArray[currentFileIndex] as TestDatum)
                                 .recording ||
-                                dataArray[currentFileIndex++].toString()
+                                dataArray[currentFileIndex].toString()
                         );
+                        currentFileIndex++;
                     }
                 }
             };


### PR DESCRIPTION
Fixed 2 bugs with batch recognition:
- The Internal Recognizer was skipping over every other file and crashing once it got to the end of it's file queue
- The MultiFIlePullStream was sending stale data instead of silence