### PR TITLE
WER moved from failure element to testcase.

### DIFF
--- a/packages/d-ser-t-service/src/MultiFilePullStream.ts
+++ b/packages/d-ser-t-service/src/MultiFilePullStream.ts
@@ -15,7 +15,6 @@ export class MultiFilePullStream extends PullAudioInputStreamCallback {
         const copyArray = new Uint8Array(dataBuffer);
 
         if (this.currentOffset >= this.currentFile.byteLength) {
-
             // The file has been fully read. Send silence back.
             copyArray.fill(0);
             return dataBuffer.byteLength;

--- a/packages/d-ser-t-service/src/XmlWriterService.ts
+++ b/packages/d-ser-t-service/src/XmlWriterService.ts
@@ -41,17 +41,20 @@ export class XmlWriterService {
 
         const testsuites = builder
             .create('testsuites', { encoding: 'utf-8' })
+            // d-ser-t-specific attributes.
+            .att('SER', metadata.sentenceErrorRate)
+            .att('AWER', metadata.averageWordErrorRate)
             // JUNIT attributes.
             .att('name', 'CRIS STT tests')
             .att('tests', testCount)
             .att('failures', failureCount)
-            .att('time', totalTestingTime)
-            // d-ser-t-specific attributes.
-            .att('SER', metadata.sentenceErrorRate)
-            .att('AWER', metadata.averageWordErrorRate);
+            .att('time', totalTestingTime);
 
         const testsuite = testsuites
             .ele('testsuite')
+            // d-ser-t-specific attributes.
+            .att('SER', metadata.sentenceErrorRate)
+            .att('AWER', metadata.averageWordErrorRate)
             // JUNIT attributes.
             .att('name', metadata.transcriptionFile)
             .att('tests', testCount)
@@ -59,10 +62,7 @@ export class XmlWriterService {
             .att('time', totalTestingTime)
             .att('timestamp', timestamp)
             .att('errors', 0)
-            .att('skipped', 0)
-            // d-ser-t-specific attributes.
-            .att('SER', metadata.sentenceErrorRate)
-            .att('AWER', metadata.averageWordErrorRate);
+            .att('skipped', 0);
 
         results.forEach((result, index) => {
             const testcase = testsuite

--- a/packages/d-ser-t-service/tests/XmlWriterService.test.ts
+++ b/packages/d-ser-t-service/tests/XmlWriterService.test.ts
@@ -38,7 +38,7 @@ afterAll(() => {
 });
 
 describe('XMLWriterService', () => {
-    describe('countNumFailures', () => {
+    describe('getFailureCount', () => {
         it('returns the correct number of failures', () => {
             const numFailures = xws.getFailureCount(mockResults);
             expect(numFailures).toEqual(1);
@@ -48,8 +48,8 @@ describe('XMLWriterService', () => {
     describe('toJUnitXml', () => {
         const expected =
             `<?xml version="1.0" encoding="utf-8"?>\n` +
-            `<testsuites name="CRIS STT tests" tests="2" failures="1" time="10" SER="0.5" AWER="0.5">\n` +
-            `  <testsuite name="test_transcription_file.txt" tests="2" failures="1" time="10" timestamp="2019-01-01 00:00:00" errors="0" skipped="0" SER="0.5" AWER="0.5">\n` +
+            `<testsuites SER="0.5" AWER="0.5" name="CRIS STT tests" tests="2" failures="1" time="10">\n` +
+            `  <testsuite SER="0.5" AWER="0.5" name="test_transcription_file.txt" tests="2" failures="1" time="10" timestamp="2019-01-01 00:00:00" errors="0" skipped="0">\n` +
             `    <testcase classname="test-1" WER="1" expected="alright" name="N/A" time="N/A">\n` +
             `      <failure actual="all right"/>\n` +
             `    </testcase>\n` +

--- a/packages/d-ser-t-service/tests/XmlWriterService.test.ts
+++ b/packages/d-ser-t-service/tests/XmlWriterService.test.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { isNumber } from 'util';
+
 import { TestMetaData, TestResult } from '../src/types';
 import { XmlWriterService } from '../src/XmlWriterService';
 
@@ -40,30 +40,20 @@ afterAll(() => {
 describe('XMLWriterService', () => {
     describe('countNumFailures', () => {
         it('returns the correct number of failures', () => {
-            const numFailures = xws.countNumFailures(mockResults);
+            const numFailures = xws.getFailureCount(mockResults);
             expect(numFailures).toEqual(1);
-        });
-    });
-
-    describe('getNumericalTime', () => {
-        const time = xws.getNumericalTime(mockMetaData);
-        it('returns a Number', () => {
-            expect(isNumber(time)).toBe(true);
-        });
-        it('returns the correct time', () => {
-            expect(time).toEqual(10);
         });
     });
 
     describe('toJUnitXml', () => {
         const expected =
             `<?xml version="1.0" encoding="utf-8"?>\n` +
-            `<testsuites name="CRIS STT tests" tests="2" failures="1" time="10" avg_SER="0.5" avg_WER="0.5">\n` +
-            `  <testsuite name="test_transcription_file.txt" errors="0" failures="1" skipped="0" timestamp="2019-01-01 00:00:00" time="10" tests="2" SER="0.5" avg_WER="0.5">\n` +
-            `    <testcase classname="test-1" name="test_transcription_file.txt" time="n/a" expected="alright">\n` +
-            `      <failure actual="all right" WER="1"/>\n` +
+            `<testsuites name="CRIS STT tests" tests="2" failures="1" time="10" SER="0.5" AWER="0.5">\n` +
+            `  <testsuite name="test_transcription_file.txt" tests="2" failures="1" time="10" timestamp="2019-01-01 00:00:00" errors="0" skipped="0" SER="0.5" AWER="0.5">\n` +
+            `    <testcase classname="test-1" WER="1" expected="alright" name="N/A" time="N/A">\n` +
+            `      <failure actual="all right"/>\n` +
             `    </testcase>\n` +
-            `    <testcase classname="test-2" name="test_transcription_file.txt" time="n/a" expected="hi"/>\n` +
+            `    <testcase classname="test-2" WER="0" expected="hi" name="N/A" time="N/A"/>\n` +
             `  </testsuite>\n` +
             `</testsuites>`;
 


### PR DESCRIPTION
Functional changes:
* XML output used to include `WER` on the `failure` element. Now it's on `failure's` parent element, `testcase`. This will make things a bit easier on when calculating the average WER once.

Other changes:
* Variable renames.
* Any unhelpful JUNIT attributes were given empty values (N/A, 0) rather than their previous values, which made the XML too busy.
* Updated XML writer tests to match new format/values of the output XML.