### PR TITLE
Bug fix for empty transcription results

### DIFF
--- a/packages/d-ser-t-service/src/MultiFilePullStream.ts
+++ b/packages/d-ser-t-service/src/MultiFilePullStream.ts
@@ -52,4 +52,8 @@ export class MultiFilePullStream extends PullAudioInputStreamCallback {
         this.currentFile = fs.readFileSync(fileName);
         this.currentOffset = 0;
     };
+
+    public finishedSendingFile = (): boolean => {
+        return this.currentOffset >= this.currentFile.byteLength;
+    }
 }

--- a/packages/d-ser-t-service/src/TranscriptionService.ts
+++ b/packages/d-ser-t-service/src/TranscriptionService.ts
@@ -227,6 +227,13 @@ export class TranscriptionService {
                             dataArray[currentFileIndex - 1].toString()
                     );
                 } else {
+
+                    if (e.result.text === "" && !stream.finishedSendingFile()) {
+                        // If we get a no-text recognition back and we haven't finished sending the file
+                        // then skip this result and wait for another one
+                        return;
+                    }
+
                     // push response into the resultArray
                     this.resultArray.push({
                         data: e.result,


### PR DESCRIPTION
Bug fix for audio files which have invalid (or empty) transcription preceding valid segments of speech.

This happened in cases when a file has some background noise or dialogue, followed by some static or silence, followed by the actual audio/dialogue we want to transcribe.
CRIS was returning a transcription for the background audio which had <5% confidence resulting in an empty/blank transcription.